### PR TITLE
Add support to resolve Backend Auth configs in runtime.

### DIFF
--- a/distribution/apim-accelerator/resources/repository/resources/operation_policies/definitions/replaceBackendAuthToken_v1.j2
+++ b/distribution/apim-accelerator/resources/repository/resources/operation_policies/definitions/replaceBackendAuthToken_v1.j2
@@ -1,3 +1,9 @@
 <class name="org.wso2.healthcare.apim.backendauth.BackendAuthenticator">
-    <property name="configName" value="{{backendAuthConfig}}"/>
+    <property name="configType" value="{{configType}}"/>
+    <property name="configValue" value="{{configValue}}"/>
+    <property name="authType" value="{{authType}}"/>
+    <property name="tokenEndpoint" value="{{tokenEndpoint}}"/>
+    <property name="clientId" value="{{clientId}}"/>
+    <property name="clientSecret" value="{{clientSecret}}"/>
+    <property name="keyAlias" value="{{keyAlias}}"/>
 </class>

--- a/distribution/apim-accelerator/resources/repository/resources/operation_policies/definitions/replaceBackendAuthToken_v1.j2
+++ b/distribution/apim-accelerator/resources/repository/resources/operation_policies/definitions/replaceBackendAuthToken_v1.j2
@@ -1,5 +1,4 @@
 <class name="org.wso2.healthcare.apim.backendauth.BackendAuthenticator">
-    <property name="configType" value="{{configType}}"/>
     <property name="configValue" value="{{configValue}}"/>
     <property name="authType" value="{{authType}}"/>
     <property name="tokenEndpoint" value="{{tokenEndpoint}}"/>

--- a/distribution/apim-accelerator/resources/repository/resources/operation_policies/specifications/replaceBackendAuthToken_v1.json
+++ b/distribution/apim-accelerator/resources/repository/resources/operation_policies/specifications/replaceBackendAuthToken_v1.json
@@ -15,18 +15,9 @@
   ],
   "policyAttributes": [
     {
-      "name": "configType",
-      "displayName": "Configuration Type",
-      "description": "Type of configuration to be used for obtaining the backend auth token.",
-      "validationRegex": "^(PREDEFINED|INLINE)$",
-      "type": "Enum",
-      "allowedValues" : ["PREDEFINED","INLINE"],
-      "required": true
-    },
-    {
       "name": "configValue",
-      "displayName": "Default Configuration",
-      "description": "Name of the default config. This value has to be an exact match with a config name in the deployment.toml [[healthcare.backend.auth]] section.",
+      "displayName": "Predefined Configuration",
+      "description": "Name of a predefined config. This value has to be an exact match with a config name in the deployment.toml [[healthcare.backend.auth]] section.",
       "type": "String",
       "required": false
     },

--- a/distribution/apim-accelerator/resources/repository/resources/operation_policies/specifications/replaceBackendAuthToken_v1.json
+++ b/distribution/apim-accelerator/resources/repository/resources/operation_policies/specifications/replaceBackendAuthToken_v1.json
@@ -15,11 +15,57 @@
   ],
   "policyAttributes": [
     {
-      "name": "backendAuthConfig",
-      "displayName": "Backend Auth Config",
-      "description": "Name of the backend auth server config. This has to an exact match with the config name in the deployment.toml [[healthcare.backend.auth]] section",
-      "type": "String",
+      "name": "configType",
+      "displayName": "Configuration Type",
+      "description": "Type of configuration to be used for obtaining the backend auth token.",
+      "validationRegex": "^(PREDEFINED|INLINE)$",
+      "type": "Enum",
+      "allowedValues" : ["PREDEFINED","INLINE"],
       "required": true
+    },
+    {
+      "name": "configValue",
+      "displayName": "Default Configuration",
+      "description": "Name of the default config. This value has to be an exact match with a config name in the deployment.toml [[healthcare.backend.auth]] section.",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "authType",
+      "displayName": "Auth Type",
+      "description": "Type of configuration to be used for obtaining the backend auth token.",
+      "validationRegex": "^(client_credentials|pkjwt)$",
+      "type": "Enum",
+      "allowedValues" : ["client_credentials","pkjwt"],
+      "required": false
+    },
+    {
+      "name": "tokenEndpoint",
+      "displayName": "Token Endpoint",
+      "description": "Applicable only if the Configuration Type is INLINE. This is the token endpoint of the external auth server",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "clientId",
+      "displayName": "Client ID",
+      "description": "Applicable only if the Configuration Type is INLINE. This is the client ID of the OAuth app in external auth server. You can enter the value inline or use a synapse expression",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "clientSecret",
+      "displayName": "Client Secret",
+      "description": "Applicable only if the Configuration Type is INLINE and Auth Type is client_credentials. This is the client secret of the OAuth app in external auth server",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "keyAlias",
+      "displayName": "Key Alias",
+      "description": "Applicable only if the Configuration Type is INLINE and Auth Type is pkjwt. This is the key alias of the private key in the keystore. You can enter the value inline or use a synapse expression",
+      "type": "String",
+      "required": false
     }
   ]
 }

--- a/product-accelerators/apim/components/org.wso2.healthcare.apim.backendauth/pom.xml
+++ b/product-accelerators/apim/components/org.wso2.healthcare.apim.backendauth/pom.xml
@@ -76,7 +76,6 @@
                         </Export-Package>
                         <Import-Package></Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
-                        <Fragment-Host>synapse-core</Fragment-Host>
                     </instructions>
                 </configuration>
             </plugin>

--- a/product-accelerators/apim/components/org.wso2.healthcare.apim.backendauth/readme.md
+++ b/product-accelerators/apim/components/org.wso2.healthcare.apim.backendauth/readme.md
@@ -9,7 +9,7 @@ retrieved token.
 
 ## Configuration Model
 This feature can be configured either through the predefined deployment.toml file using TOML configuration or inline by 
-specifying policy attributes directly while enabling the policy.
+specifying policy attributes directly when enabling the policy.
 
 ### 1. PREDEFINED CONFIGURATION
 
@@ -38,7 +38,7 @@ private_key_alias = "key_alias" # Only for PKJWT flow
 
 ### 2. INLINE CONFIGURATION
 
-In Inline mode, 'Config Value' is treated as the default configuration element, while following configuration settings 
+In Inline mode, 'Config Value' is treated as the master configuration element, while following configuration settings 
 can be overridden inline as needed. Additionally, `client_id` and `private_key_alias` configurations can be extracted from 
 request headers or context properties by specifying them as Synapse expressions (e.g., `$header:<header_name>, $ctx:<property_name>`).
 
@@ -50,6 +50,7 @@ request headers or context properties by specifying them as Synapse expressions 
 | `client_secret`     | The client secret associated with the client ID (if applicable).                                                   | `client_secret`                               |
 | `private_key_alias` | The alias of the private key used for signing JWTs (if applicable). This key must be added to the Primary Keystore | `key_alias` or `$ctx:property`                |
 
+Also, when using both predefined and inline configurations, the inline configuration will take precedence over the predefined configuration.
 
 ## Key Features
 
@@ -93,5 +94,8 @@ keytool -importkeystore \
   -srcalias <alias_used_in_p12> \
   -destalias <alias_to_be_used_in_JKS>
 ```
+
+### Limitations
+- This feature is recommended for use as API-level policy. There may be unexpected behavior if used as a global policy.
 
 

--- a/product-accelerators/apim/components/org.wso2.healthcare.apim.backendauth/readme.md
+++ b/product-accelerators/apim/components/org.wso2.healthcare.apim.backendauth/readme.md
@@ -8,6 +8,13 @@ from an external OAuth 2.0-compliant authentication server and replacing the `Au
 retrieved token.
 
 ## Configuration Model
+This feature can be configured either through the predefined deployment.toml file using TOML configuration or inline by 
+specifying policy attributes directly while enabling the policy.
+
+### 1. PREDEFINED CONFIGURATION
+
+In PREDEFINED mode, configuration values must be specified in the deployment.toml file, and the configuration name 
+should be referenced in the 'Config Value' policy attribute.
 
 ```toml
 [[healthcare.backend.auth]]
@@ -28,6 +35,20 @@ private_key_alias = "key_alias" # Only for PKJWT flow
 | `client_id`         | The client identifier registered with the auth server.                                                                                                   | `client_id`                                   |
 | `client_secret`     | The client secret associated with the client ID (if applicable).                                                                                         | `client_secret`                               |
 | `private_key_alias` | The alias of the private key used for signing JWTs (if applicable). This key must be added to the Primary Keystore                                       | `key_alias`                                   |
+
+### 2. INLINE CONFIGURATION
+
+In Inline mode, 'Config Value' is treated as the default configuration element, while following configuration settings 
+can be overridden inline as needed. Additionally, `client_id` and `private_key_alias` configurations can be extracted from 
+request headers or context properties by specifying them as Synapse expressions (e.g., `$header:<header_name>, $ctx:<property_name>`).
+
+| Parameter           | Description                                                                                                        | Example Value                                 |
+|---------------------|--------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
+| `auth_type`         | Authentication type. Only `pkjwt` and `client_credentials` are supported atm.                                      | `pkjwt`                                       |
+| `token_endpoint`    | The URL of the external auth server's token endpoint for obtaining tokens.                                         | `https://external.auth.com:9443/oauth2/token` |
+| `client_id`         | The client identifier registered with the auth server. Synapse expressions allowed.                                | `client_id` or `$header:client_id`            |
+| `client_secret`     | The client secret associated with the client ID (if applicable).                                                   | `client_secret`                               |
+| `private_key_alias` | The alias of the private key used for signing JWTs (if applicable). This key must be added to the Primary Keystore | `key_alias` or `$ctx:property`                |
 
 
 ## Key Features

--- a/product-accelerators/apim/components/org.wso2.healthcare.apim.backendauth/src/main/java/org/wso2/healthcare/apim/backendauth/BackendAuthenticator.java
+++ b/product-accelerators/apim/components/org.wso2.healthcare.apim.backendauth/src/main/java/org/wso2/healthcare/apim/backendauth/BackendAuthenticator.java
@@ -44,7 +44,6 @@ public class BackendAuthenticator extends AbstractMediator {
     private String clientId;
     private char[] clientSecret;
     private String keyAlias;
-    @SuppressWarnings("FieldCanBeLocal")
     private String configValue;
     private final Map<String, BackendAuthConfig> backendAuthConfig;
     private BackendAuthConfig masterConfig;
@@ -63,10 +62,10 @@ public class BackendAuthenticator extends AbstractMediator {
             log.debug("Backend authenticator mediator is invoked.");
         }
 
-        if (masterConfig.getClientId()!=null && masterConfig.getClientId().contains("$")){
+        if (masterConfig.getClientId() != null && masterConfig.getClientId().contains("$")) {
             masterConfig.setClientId(Utils.resolveConfigValues(this.clientId, messageContext));
         }
-        if (masterConfig.getPrivateKeyAlias()!=null && masterConfig.getPrivateKeyAlias().contains("$")){
+        if (masterConfig.getPrivateKeyAlias() != null && masterConfig.getPrivateKeyAlias().contains("$")) {
             masterConfig.setPrivateKeyAlias(Utils.resolveConfigValues(this.keyAlias, messageContext));
         }
 
@@ -118,10 +117,9 @@ public class BackendAuthenticator extends AbstractMediator {
         return true;
     }
 
-    @SuppressWarnings("Setters will be called by the ESB config builder")
     public void setAuthType(String authType) {
         this.authType = authType;
-        if (!StringUtils.isEmpty(this.authType)){
+        if (!StringUtils.isEmpty(this.authType)) {
             masterConfig.setAuthType(authType);
         }
     }
@@ -130,35 +128,35 @@ public class BackendAuthenticator extends AbstractMediator {
         this.configValue = configValue;
         if (backendAuthConfig.containsKey(configValue)) {
             masterConfig = backendAuthConfig.get(configValue);
-        }else{
+        } else {
             masterConfig = new BackendAuthConfig();
         }
     }
 
     public void setTokenEndpoint(String tokenEndpoint) {
         this.tokenEndpoint = tokenEndpoint;
-        if (!StringUtils.isEmpty(tokenEndpoint)){
+        if (!StringUtils.isEmpty(tokenEndpoint)) {
             masterConfig.setAuthEndpoint(tokenEndpoint);
         }
     }
 
     public void setClientId(String clientId) {
         this.clientId = clientId;
-        if (!StringUtils.isEmpty(clientId)){
+        if (!StringUtils.isEmpty(clientId)) {
             masterConfig.setClientId(clientId);
         }
     }
 
     public void setClientSecret(String clientSecret) {
         this.clientSecret = clientSecret.toCharArray();
-        if (this.clientSecret.length != 0){
+        if (this.clientSecret.length != 0) {
             masterConfig.setClientSecret(clientSecret.toCharArray());
         }
     }
 
     public void setKeyAlias(String keyAlias) {
         this.keyAlias = keyAlias;
-        if (!StringUtils.isEmpty(keyAlias)){
+        if (!StringUtils.isEmpty(keyAlias)) {
             masterConfig.setPrivateKeyAlias(keyAlias);
         }
     }

--- a/product-accelerators/apim/components/org.wso2.healthcare.apim.backendauth/src/main/java/org/wso2/healthcare/apim/backendauth/BackendAuthenticator.java
+++ b/product-accelerators/apim/components/org.wso2.healthcare.apim.backendauth/src/main/java/org/wso2/healthcare/apim/backendauth/BackendAuthenticator.java
@@ -62,12 +62,7 @@ public class BackendAuthenticator extends AbstractMediator {
             log.debug("Backend authenticator mediator is invoked.");
         }
 
-        if (masterConfig.getClientId() != null && masterConfig.getClientId().contains("$")) {
-            masterConfig.setClientId(Utils.resolveConfigValues(this.clientId, messageContext));
-        }
-        if (masterConfig.getPrivateKeyAlias() != null && masterConfig.getPrivateKeyAlias().contains("$")) {
-            masterConfig.setPrivateKeyAlias(Utils.resolveConfigValues(this.keyAlias, messageContext));
-        }
+        Utils.resolveConfigValues(masterConfig, messageContext);
 
         if (!Utils.validateConfig(masterConfig)) {
             log.error("Config validation failed.");

--- a/product-accelerators/apim/components/org.wso2.healthcare.apim.backendauth/src/main/java/org/wso2/healthcare/apim/backendauth/Utils.java
+++ b/product-accelerators/apim/components/org.wso2.healthcare.apim.backendauth/src/main/java/org/wso2/healthcare/apim/backendauth/Utils.java
@@ -21,6 +21,7 @@ package org.wso2.healthcare.apim.backendauth;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpEntity;
@@ -49,6 +50,7 @@ import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.healthcare.apim.backendauth.tokenmgt.Token;
 import org.wso2.healthcare.apim.core.OpenHealthcareException;
 import org.wso2.healthcare.apim.core.OpenHealthcareRuntimeException;
+import org.wso2.healthcare.apim.core.config.BackendAuthConfig;
 
 import javax.net.ssl.SSLContext;
 import java.io.FileInputStream;
@@ -299,8 +301,8 @@ public class Utils {
      * Evaluate synapse configValue and return the value.
      * Supported expressions: $header:<header_name>, $ctx:<property_name>
      *
-     * @param configValue      - configValue to evaluate
-     * @param messageContext  - message context
+     * @param configValue    - configValue to evaluate
+     * @param messageContext - message context
      * @return - evaluated value
      */
     public static String resolveConfigValues(String configValue, MessageContext messageContext) {
@@ -322,8 +324,10 @@ public class Utils {
             Object headers = axisMsgCtx.getProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
             if (headers instanceof Map) {
                 Map headersMap = (Map) headers;
-                if (headersMap.get(headerName) != null) {
-                    log.info("Header value: " + headersMap.get(headerName));
+                if (headersMap.containsKey(headerName)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Header value: " + headersMap.get(headerName));
+                    }
                     return (String) headersMap.get(headerName);
                 }
                 axisMsgCtx.setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS, headersMap);
@@ -334,5 +338,28 @@ public class Utils {
             log.error("Message context is not an instance of Axis2MessageContext.");
         }
         return null;
+    }
+
+    /**
+     * Validate the backend auth config.
+     * @param config - BackendAuthConfig object
+     * @return true if valid
+     */
+    public static boolean validateConfig(BackendAuthConfig config) {
+
+        if (StringUtils.isEmpty(config.getAuthType()) || StringUtils.isEmpty(config.getAuthEndpoint()) ||
+                StringUtils.isEmpty(config.getClientId())) {
+            log.error("One or more required configs are missing in the policy attributes.");
+            return false;
+        } else if (Constants.POLICY_ATTR_AUTH_TYPE_PKJWT.equals(config.getAuthType()) &&
+                StringUtils.isEmpty(config.getPrivateKeyAlias())) {
+            log.error("Key alias is missing in the policy attributes.");
+            return false;
+        } else if (Constants.POLICY_ATTR_AUTH_TYPE_CLIENT_CRED.equals(config.getAuthType()) &&
+                config.getClientSecret().length == 0) {
+            log.error("Client secret is missing in the policy attributes.");
+            return false;
+        }
+        return true;
     }
 }

--- a/product-accelerators/apim/components/org.wso2.healthcare.apim.core/src/main/java/org/wso2/healthcare/apim/core/config/OpenHealthcareConfig.java
+++ b/product-accelerators/apim/components/org.wso2.healthcare.apim.core/src/main/java/org/wso2/healthcare/apim/core/config/OpenHealthcareConfig.java
@@ -591,15 +591,17 @@ public class OpenHealthcareConfig {
                     TomlTable beAuthTable = (TomlTable) notification;
                     BackendAuthConfig backendAuthConfig = new BackendAuthConfig();
                     if (StringUtils.isEmpty(beAuthTable.getString("name")) ||
-                            StringUtils.isEmpty(beAuthTable.getString("token_endpoint")) ||
-                            StringUtils.isEmpty(beAuthTable.getString("auth_type")) ||
-                            StringUtils.isEmpty(beAuthTable.getString("client_id"))) {
+                            StringUtils.isEmpty(beAuthTable.getString("token_endpoint"))) {
                         throw new OpenHealthcareException("One or more mandatory parameter/s in the notification " +
-                                "config missing. [Mandatory params - name, token_endpoint, client_id]");
+                                "config missing. [Mandatory params - name, token_endpoint]");
                     }
                     backendAuthConfig.setName(beAuthTable.getString("name"));
                     backendAuthConfig.setAuthEndpoint(beAuthTable.getString("token_endpoint"));
                     backendAuthConfig.setClientId(beAuthTable.getString("client_id"));
+                    String clientId = beAuthTable.getString("client_id", () -> null);
+                    if (clientId != null) {
+                        backendAuthConfig.setClientId(clientId);
+                    }
                     String keyAlias = beAuthTable.getString("private_key_alias", () -> null);
                     if (keyAlias != null) {
                         backendAuthConfig.setPrivateKeyAlias(keyAlias);


### PR DESCRIPTION
## Purpose
> Add dynamic config resolution capability.
fix: https://github.com/wso2/healthcare-accelerator/issues/9

## Goals
> As requested by a customer to improve the usability.

## Approach
> Introduced inline mode to allow configs in the API configuring time. Selected configs are allowed to get Synapse expressions that resolves in runtime.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> 