### PR TITLE
Remove OASParserUtil dependency as it removed from base product.

### DIFF
--- a/product-accelerators/apim/components/org.wso2.healthcare.apim.conformance/src/main/java/org/wso2/healthcare/apim/conformance/ConformanceMediator.java
+++ b/product-accelerators/apim/components/org.wso2.healthcare.apim.conformance/src/main/java/org/wso2/healthcare/apim/conformance/ConformanceMediator.java
@@ -18,7 +18,6 @@
 
 package org.wso2.healthcare.apim.conformance;
 
-import com.google.gson.JsonObject;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.axis2.AxisFault;
@@ -39,14 +38,12 @@ import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerFactory;
-import org.wso2.carbon.apimgt.impl.definitions.OASParserUtil;
 import org.wso2.carbon.governance.api.util.GovernanceArtifactConfiguration;
 import org.wso2.carbon.governance.api.util.GovernanceUtils;
 import org.wso2.carbon.registry.core.Registry;
 import org.wso2.carbon.registry.core.exceptions.RegistryException;
 import org.wso2.carbon.registry.core.session.UserRegistry;
 import org.wso2.carbon.user.api.UserStoreException;
-import org.wso2.healthcare.apim.conformance.internal.ConformanceDataHolder;
 import org.wso2.healthcare.apim.core.OpenHealthcareException;
 import org.wso2.healthcare.apim.core.api.server.FHIRServerConfigAPI;
 
@@ -239,18 +236,12 @@ public class ConformanceMediator extends AbstractMediator {
         for (API api : allMatchedApis) {
             String apiDefinitionContent;
             OASHandler handler = null;
-            try {
-                apiDefinitionContent = api.getSwaggerDefinition();
-                if (OASParserUtil.SwaggerVersion.SWAGGER.equals(OASParserUtil.getSwaggerVersion(
-                        apiDefinitionContent))) {
-                    handler = new OAS2Handler(apiDefinitionContent);
-                } else if (OASParserUtil.SwaggerVersion.OPEN_API
-                        .equals(OASParserUtil.getSwaggerVersion(apiDefinitionContent))) {
-                    handler = new OAS3Handler(apiDefinitionContent);
-                }
-            } catch (APIManagementException e) {
-                LOG.error("Error occurred while retrieving OpenAPI definition", e);
-                throw new ConformanceMediatorException("Error occurred while retrieving OpenAPI definition", e);
+            apiDefinitionContent = api.getSwaggerDefinition();
+            Util.SwaggerVersion swaggerVersion = Util.getSwaggerVersion(apiDefinitionContent);
+            if (Util.SwaggerVersion.SWAGGER.equals(swaggerVersion)) {
+                handler = new OAS2Handler(apiDefinitionContent);
+            } else if (Util.SwaggerVersion.OPEN_API.equals(swaggerVersion)) {
+                handler = new OAS3Handler(apiDefinitionContent);
             }
 
             if (handler != null) {

--- a/product-accelerators/apim/components/org.wso2.healthcare.apim.conformance/src/main/java/org/wso2/healthcare/apim/conformance/ConformanceMediator.java
+++ b/product-accelerators/apim/components/org.wso2.healthcare.apim.conformance/src/main/java/org/wso2/healthcare/apim/conformance/ConformanceMediator.java
@@ -234,6 +234,8 @@ public class ConformanceMediator extends AbstractMediator {
 
         //iterate for all APIs
         for (API api : allMatchedApis) {
+            LOG.debug(String.format("Processing API: %s version: %s for capability statement",
+                    api.getId().getName(), api.getId().getVersion()));
             String apiDefinitionContent;
             OASHandler handler = null;
             apiDefinitionContent = api.getSwaggerDefinition();
@@ -245,6 +247,8 @@ public class ConformanceMediator extends AbstractMediator {
             }
 
             if (handler != null) {
+                LOG.debug(String.format("Successfully initialized %s handler for API: %s",
+                        swaggerVersion, api.getId().getName()));
                 Map<String, Object> extensions = handler.getVendorExtentions();
                 if (extensions == null) {
                     continue;

--- a/product-accelerators/apim/components/org.wso2.healthcare.apim.conformance/src/main/java/org/wso2/healthcare/apim/conformance/Util.java
+++ b/product-accelerators/apim/components/org.wso2.healthcare.apim.conformance/src/main/java/org/wso2/healthcare/apim/conformance/Util.java
@@ -20,6 +20,7 @@ package org.wso2.healthcare.apim.conformance;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.commons.lang.StringUtils;
@@ -265,6 +266,51 @@ public class Util {
             throw new ConformanceMediatorException("Error occurred while calling key manager well-known endpoint", e);
         }
         return wellKnownResponse;
+    }
+
+    /**
+     * Swagger/OpenAPI spec version, used to select the appropriate OAS handler.
+     */
+    public enum SwaggerVersion {
+        SWAGGER,   // OAS 2 — top-level "swagger" key
+        OPEN_API,  // OAS 3 — top-level "openapi" key
+        UNKNOWN
+    }
+
+    /**
+     * Determine the OAS version of an API definition string without relying on
+     * the deprecated {@code OASParserUtil.getSwaggerVersion()} from apimgt.
+     *
+     * <p>Detection rules:
+     * <ul>
+     *   <li>Presence of a top-level {@code "swagger"} key → {@link SwaggerVersion#SWAGGER} (OAS 2)</li>
+     *   <li>Presence of a top-level {@code "openapi"} key → {@link SwaggerVersion#OPEN_API} (OAS 3)</li>
+     *   <li>Anything else or a parse error → {@link SwaggerVersion#UNKNOWN}</li>
+     * </ul>
+     *
+     * @param apiDefinition raw JSON string of the API definition
+     * @return detected {@link SwaggerVersion}
+     */
+    public static SwaggerVersion getSwaggerVersion(String apiDefinition) {
+        if (apiDefinition == null || apiDefinition.isEmpty()) {
+            return SwaggerVersion.UNKNOWN;
+        }
+        try {
+            JsonElement root = JsonParser.parseString(apiDefinition);
+            if (!root.isJsonObject()) {
+                return SwaggerVersion.UNKNOWN;
+            }
+            JsonObject obj = root.getAsJsonObject();
+            if (obj.has("swagger")) {
+                return SwaggerVersion.SWAGGER;
+            }
+            if (obj.has("openapi")) {
+                return SwaggerVersion.OPEN_API;
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to parse API definition to determine OAS version", e);
+        }
+        return SwaggerVersion.UNKNOWN;
     }
 
     /**

--- a/product-accelerators/apim/components/org.wso2.healthcare.apim.conformance/src/main/java/org/wso2/healthcare/apim/conformance/Util.java
+++ b/product-accelerators/apim/components/org.wso2.healthcare.apim.conformance/src/main/java/org/wso2/healthcare/apim/conformance/Util.java
@@ -311,7 +311,16 @@ public class Util {
                 return SwaggerVersion.OPEN_API;
             }
         } catch (Exception e) {
+            // Fallback for YAML definitions
+            String normalized = apiDefinition.trim();
+            if (normalized.startsWith("swagger:")) {
+                return SwaggerVersion.SWAGGER;
+            }
+            if (normalized.startsWith("openapi:")) {
+                return SwaggerVersion.OPEN_API;
+            }
             LOG.warn("Failed to parse API definition to determine OAS version", e);
+
         }
         return SwaggerVersion.UNKNOWN;
     }

--- a/product-accelerators/apim/components/org.wso2.healthcare.apim.conformance/src/main/java/org/wso2/healthcare/apim/conformance/Util.java
+++ b/product-accelerators/apim/components/org.wso2.healthcare.apim.conformance/src/main/java/org/wso2/healthcare/apim/conformance/Util.java
@@ -293,6 +293,7 @@ public class Util {
      */
     public static SwaggerVersion getSwaggerVersion(String apiDefinition) {
         if (apiDefinition == null || apiDefinition.isEmpty()) {
+            LOG.debug("API definition is null or empty, returning UNKNOWN version");
             return SwaggerVersion.UNKNOWN;
         }
         try {
@@ -302,9 +303,11 @@ public class Util {
             }
             JsonObject obj = root.getAsJsonObject();
             if (obj.has("swagger")) {
+                LOG.debug("Detected OAS 2 (Swagger) API definition");
                 return SwaggerVersion.SWAGGER;
             }
             if (obj.has("openapi")) {
+                LOG.debug("Detected OAS 3 (OpenAPI) API definition");
                 return SwaggerVersion.OPEN_API;
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Purpose
> fix error in the metadata endpoint.
```
java.lang.NoClassDefFoundError: org/wso2/carbon/apimgt/impl/definitions/OASParserUtil$SwaggerVersion
	at org.wso2.healthcare.apim.conformance.ConformanceMediator.createCapabilityStatement(ConformanceMediator.java:244)
	at org.wso2.healthcare.apim.conformance.ConformanceMediator.mediate(ConformanceMediator.java:86)
	at org.apache.synapse.mediators.ext.ClassMediator.updateInstancePropertiesAndMediate(ClassMediator.java:253)
	at org.apache.synapse.mediators.ext.ClassMediator.mediate(ClassMediator.java:115)
	at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:132)
	at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:79)
	at org.apache.synapse.mediators.base.SequenceMediator.mediate(SequenceMediator.java:158)
	at org.apache.synapse.api.Resource.process(Resource.java:355)
	at org.apache.synapse.api.Resource.process(Resource.java:303)
	at org.apache.synapse.api.API.process(API.java:505)
	at org.apache.synapse.api.AbstractApiHandler.apiProcess(AbstractApiHandler.java:95)
	at org.apache.synapse.api.AbstractApiHandler.dispatchToAPI(AbstractApiHandler.java:73)
	at org.apache.synapse.api.rest.RestRequestHandler.dispatchToAPI(RestRequestHandler.java:90)
	at org.apache.synapse.api.rest.RestRequestHandler.process(RestRequestHandler.java:76)
	at org.apache.synapse.rest.RESTRequestHandler.process(RESTRequestHandler.java:54)
	at org.apache.synapse.core.axis2.Axis2SynapseEnvironment.injectMessage(Axis2SynapseEnvironment.java:352)
	at org.apache.synapse.core.axis2.SynapseMessageReceiver.receive(SynapseMessageReceiver.java:101)
	at org.apache.axis2.engine.AxisEngine.receive(AxisEngine.java:180)
	at org.apache.synapse.transport.passthru.ServerWorker.processNonEntityEnclosingRESTHandler(ServerWorker.java:401)
	at org.apache.synapse.transport.passthru.ServerWorker.run(ServerWorker.java:215)
	at org.apache.axis2.transport.base.threads.NativeWorkerPool$1.run(NativeWorkerPool.java:172)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.ClassNotFoundException: org.wso2.carbon.apimgt.impl.definitions.OASParserUtil$SwaggerVersion cannot be found by synapse-core_4.0.0.wso2v262_8
	... 24 more
	
```