### PR TITLE
Fixes #21: Apply HTML attribute encoding to user inputs in JSP pages

### DIFF
--- a/product-accelerators/apim/apps/authentication-portal/src/main/resources/custom/basicauth.jsp
+++ b/product-accelerators/apim/apps/authentication-portal/src/main/resources/custom/basicauth.jsp
@@ -276,7 +276,7 @@
             </div>
         </div>
     <% } else { %>
-        <input id="username" name="username" type="hidden" data-testid="login-page-username-input" value="<%=username%>">
+        <input id="username" name="username" type="hidden" data-testid="login-page-username-input" value="<%=Encode.forHtmlAttribute(username)%>">
     <% } %>
         <div class="fieldContainer">
             <div class="material-textfield">

--- a/product-accelerators/apim/apps/authentication-portal/src/main/resources/custom/includes/header.jsp
+++ b/product-accelerators/apim/apps/authentication-portal/src/main/resources/custom/includes/header.jsp
@@ -26,6 +26,7 @@
 <%@ page import="java.net.URI"%>
 <%@ page import="org.apache.commons.lang.StringUtils"%>
 <%@ page import="org.wso2.healthcare.apim.core.api.server.DeploymentConfigAPI" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <%
   String tenant = request.getParameter("tenantDomain");
@@ -142,7 +143,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<link rel="icon" href=<%=request.getAttribute("faviconSrc")%> type="image/x-icon"/>
+<link rel="icon" href="<%=Encode.forHtmlAttribute((String)request.getAttribute("faviconSrc"))%>" type="image/x-icon"/>
 
 <title><%=request.getAttribute("pageTitle")%></title>
 
@@ -630,7 +631,7 @@
   String cssPath = request.getAttribute("customCSS") + "";
   if (!StringUtils.isEmpty(cssPath)) {
 %>
-      <link href=<%=cssPath%> rel="stylesheet" type="text/css">
+      <link href="<%=Encode.forHtmlAttribute(cssPath)%>" rel="stylesheet" type="text/css">
 <%	}
 %>
 

--- a/product-accelerators/apim/apps/identity-shared/src/main/resources/extensions/header.jsp
+++ b/product-accelerators/apim/apps/identity-shared/src/main/resources/extensions/header.jsp
@@ -26,6 +26,7 @@
 <%@ page import="java.net.URI"%>
 <%@ page import="org.apache.commons.lang.StringUtils"%>
 <%@ page import="org.wso2.healthcare.apim.core.api.server.DeploymentConfigAPI" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
@@ -241,7 +242,7 @@
   String cssPath = request.getAttribute("customCSS") + "";
   if (!StringUtils.isEmpty(cssPath)) {
 %>
-      <link href=<%=cssPath%> rel="stylesheet" type="text/css">
+      <link href="<%=Encode.forHtmlAttribute(cssPath)%>" rel="stylesheet" type="text/css">
 <%	}
 %>
 

--- a/product-accelerators/apim/apps/identity-shared/src/main/resources/extensions/product-title.jsp
+++ b/product-accelerators/apim/apps/identity-shared/src/main/resources/extensions/product-title.jsp
@@ -39,15 +39,17 @@
     String logoHeight = (String)request.getAttribute("logoHeight");
     String logoWidth = (String)request.getAttribute("logoWidth");
     String logoAltText = (String)request.getAttribute("logoAltText");
+    Object headerTitleObj = request.getAttribute("headerTitle");
+    String headerTitle = headerTitleObj != null ? headerTitleObj.toString() : "";
     if (!StringUtils.isEmpty(logoSrc)) {
 %>
         <div class="product-title box">
             <img src="<%=Encode.forHtmlAttribute(logoSrc)%>" alt="<%=Encode.forHtmlAttribute(logoAltText)%>" height="<%=Encode.forHtmlAttribute(logoHeight)%>" width="<%=Encode.forHtmlAttribute(logoWidth)%>">
-           <h1 class="product-title-text"><%=Encode.forHtml(request.getAttribute("headerTitle") != null ? request.getAttribute("headerTitle").toString() : "")%></h1>
+            <h1 class="product-title-text"><%=Encode.forHtml(headerTitle)%></h1>
         </div>
 <%  } else { %>
         <div class="product-title box">
-            <h1 class="product-title-text" vertical-align="middle"><%=request.getAttribute("headerTitle")%></h1>
+            <h1 class="product-title-text" style="vertical-align: middle;"><%=Encode.forHtml(headerTitle)%></h1>
         </div>
 <%  } %>
 <% } %>

--- a/product-accelerators/apim/apps/identity-shared/src/main/resources/extensions/product-title.jsp
+++ b/product-accelerators/apim/apps/identity-shared/src/main/resources/extensions/product-title.jsp
@@ -43,7 +43,7 @@
 %>
         <div class="product-title box">
             <img src="<%=Encode.forHtmlAttribute(logoSrc)%>" alt="<%=Encode.forHtmlAttribute(logoAltText)%>" height="<%=Encode.forHtmlAttribute(logoHeight)%>" width="<%=Encode.forHtmlAttribute(logoWidth)%>">
-            <h1 class="product-title-text"><%=request.getAttribute("headerTitle")%></h1>
+           <h1 class="product-title-text"><%=Encode.forHtml(request.getAttribute("headerTitle") != null ? request.getAttribute("headerTitle").toString() : "")%></h1>
         </div>
 <%  } else { %>
         <div class="product-title box">

--- a/product-accelerators/apim/apps/identity-shared/src/main/resources/extensions/product-title.jsp
+++ b/product-accelerators/apim/apps/identity-shared/src/main/resources/extensions/product-title.jsp
@@ -19,6 +19,7 @@
 <!-- localize.jsp MUST already be included in the calling script -->
 
 <%@ page import="org.apache.commons.lang.StringUtils"%>
+<%@ page import="org.owasp.encoder.Encode"%>
 
 <% if ("API Manager".equals(request.getAttribute("headerTitle"))) { %>
 <div class="product-title">
@@ -41,7 +42,7 @@
     if (!StringUtils.isEmpty(logoSrc)) {
 %>
         <div class="product-title box">
-            <img src=<%=logoSrc%> alt=<%=logoAltText%> height=<%=logoHeight%> width=<%=logoWidth%>>
+            <img src="<%=Encode.forHtmlAttribute(logoSrc)%>" alt="<%=Encode.forHtmlAttribute(logoAltText)%>" height="<%=Encode.forHtmlAttribute(logoHeight)%>" width="<%=Encode.forHtmlAttribute(logoWidth)%>">
             <h1 class="product-title-text"><%=request.getAttribute("headerTitle")%></h1>
         </div>
 <%  } else { %>

--- a/product-accelerators/apim/apps/recovery-portal/src/main/resources/custom/includes/header.jsp
+++ b/product-accelerators/apim/apps/recovery-portal/src/main/resources/custom/includes/header.jsp
@@ -26,6 +26,7 @@
 <%@ page import="java.net.URI"%>
 <%@ page import="org.apache.commons.lang.StringUtils"%>
 <%@ page import="org.wso2.healthcare.apim.core.api.server.DeploymentConfigAPI" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <%
   String tenant = request.getParameter("tenantDomain");
@@ -151,7 +152,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<link rel="icon" href=<%=request.getAttribute("faviconSrc")%> type="image/x-icon"/>
+<link rel="icon" href="<%=Encode.forHtmlAttribute((String)request.getAttribute("faviconSrc"))%>" type="image/x-icon"/>
 
 <title><%=request.getAttribute("pageTitle")%></title>
 
@@ -684,7 +685,7 @@
   String cssPath = request.getAttribute("customCSS") + "";
   if (!StringUtils.isEmpty(cssPath)) {
 %>
-      <link href=<%=cssPath%> rel="stylesheet" type="text/css">
+      <link href="<%=Encode.forHtmlAttribute(cssPath)%>" rel="stylesheet" type="text/css">
 <%	}
 %>
 


### PR DESCRIPTION
This PR resolves #21 by properly quoting and HTML attribute encoding user-influenced inputs/variables inside HTML attributes in JSP files to prevent broken layouts and potential XSS/HTML injection.